### PR TITLE
fix: skip workspace initialization for utility and shell completion commands

### DIFF
--- a/cmd/fjira-cli/commands/root.go
+++ b/cmd/fjira-cli/commands/root.go
@@ -17,16 +17,44 @@ const (
 
 var InvalidIssueKeyFormatErr = errors.New("invalid issue key format")
 
+// shouldSkipWorkspaceInitialization determines if a command should skip workspace initialization.
+func shouldSkipWorkspaceInitialization(cmd *cobra.Command) bool {
+	cmdName := cmd.Name()
+
+	// Skip for utility commands
+	if cmdName == "version" || cmdName == "help" || cmdName == "completion" {
+		return true
+	}
+
+	// Skip for completion subcommands
+	if cmd.Parent() != nil && cmd.Parent().Name() == "completion" {
+		return true
+	}
+
+	// Skip for shell completion commands
+	shellCompletionCommands := []string{"bash", "zsh", "fish", "powershell"}
+	for _, shellCmd := range shellCompletionCommands {
+		if cmdName == shellCmd {
+			return true
+		}
+	}
+
+	return false
+}
+
 func GetRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fjira",
 		Short: "A fuzzy jira tui application",
 		Long: `Fjira is a powerful terminal user interface (TUI) application designed to streamline your Jira workflow.
-With its fuzzy-find capabilities, it simplifies the process of searching and accessing Jira issues, 
+With its fuzzy-find capabilities, it simplifies the process of searching and accessing Jira issues,
 making it easier than ever to locate and manage your tasks and projects efficiently.
 Say goodbye to manual searching and hello to increased productivity with fjira.`,
 		Args: cobra.MaximumNArgs(2),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if shouldSkipWorkspaceInitialization(cmd) {
+				return nil
+			}
 			// it's initializing fjira before every command
 			s, err := fjira.Install("")
 			if err != nil {


### PR DESCRIPTION
right now `version` and `completion` trigger workspace init run, update to skip it.