### PR TITLE
docs: update to use homebrew core tap

### DIFF
--- a/.github/workflows/release-precheck.yml
+++ b/.github/workflows/release-precheck.yml
@@ -51,7 +51,6 @@ jobs:
           args: release --skip publish --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
           AUR_KEY: ${{ secrets.AUR_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,19 +24,7 @@ release:
   mode: replace
   header: |
     ## Release ({{ .Version }})
-homebrew_casks:
-  - name: fjira
-    repository:
-      owner: mk-5
-      name: homebrew-mk-5
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    commit_author:
-      name: mk-5
-      email: mateusz+goreleaser@mk5.pl
-    commit_msg_template: "misc: brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-    homepage: "https://github.com/mk-5/fjira"
-    license: "AGPL-3.0-only"
+
 archives:
   - id: fjira
     formats: [tar.gz]

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ before.
 
 ## Installation
 
-### macOS
+### Homebrew (macOS/Linux)
 
 ```shell
-brew tap mk-5/mk-5
-brew install fjira
+$ brew install fjira
 ```
 
 ### Linux


### PR DESCRIPTION
update to use homebrew core tap and remove the custom tap setup (it would be managed by [autobump process](https://github.com/Homebrew/homebrew-core/actions/workflows/autobump.yml))

- https://github.com/Homebrew/homebrew-core/pull/244338