### PR TITLE
fix: goroutine leak in filters view

### DIFF
--- a/internal/filters/filters_search.go
+++ b/internal/filters/filters_search.go
@@ -86,7 +86,10 @@ func (view *filtersSearchView) startFiltersFuzzyFind() {
 
 func (view *filtersSearchView) handleBottomBarActions() {
 	for {
-		action := <-view.bottomBar.Action
+		action, ok := <-view.bottomBar.Action
+		if !ok {
+			return
+		}
 		switch action {
 		case ui.ActionCancel:
 			view.cancel()


### PR DESCRIPTION
Fixed a goroutine leak in the filters view caused from BottomBar action
handler not checking if the channel closed.
This caused increased CPU usage with each navigation between the filters
and issues lists.
