### PR TITLE
Board view overhaul: fixes, --board flag, F2 assignee filter, F6 Create Issue, issue-aware nav

### DIFF
--- a/cmd/fjira-cli/commands/root.go
+++ b/cmd/fjira-cli/commands/root.go
@@ -77,16 +77,19 @@ Say goodbye to manual searching and hello to increased productivity with fjira.`
 				return issueCmd.ExecuteContext(cmd.Context())
 			}
 			projectKey, _ := cmd.Flags().GetString("project")
+			boardId, _ := cmd.Flags().GetInt("board")
 			s := cmd.Context().Value(CtxWorkspaceSettings).(*workspaces.WorkspaceSettings)
 			f := fjira.CreateNewFjira(s)
 			defer f.Close()
 			f.Run(&fjira.CliArgs{
 				ProjectId: projectKey,
+				BoardId:   boardId,
 			})
 			return nil
 		},
 	}
 	cmd.AddCommand(&cobra.Command{Use: "", Short: "Open a fuzzy finder for projects as a default action"})
 	cmd.Flags().StringP("project", "p", "", "Open a project directly from CLI")
+	cmd.Flags().Int("board", 0, "Open a board directly from CLI (by board id)")
 	return cmd
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -11,6 +12,15 @@ import (
 	"github.com/gdamore/tcell/v2"
 	_ "github.com/gdamore/tcell/v2/encoding"
 )
+
+var lastViewedBoardID int
+
+// SetLastViewedBoardID is called by board view on construction.
+// On shutdown, fjira prints the last id to stdout for muscle-memory
+// recall — `fjira --board=$(...)` round-trips trivially.
+func SetLastViewedBoardID(id int) {
+	lastViewedBoardID = id
+}
 
 type App struct {
 	ScreenX      int
@@ -171,6 +181,9 @@ func (a *App) Close() {
 	a.screen.Show()
 	a.screen.Fini()
 	close(a.keyEvent)
+	if lastViewedBoardID != 0 {
+		fmt.Fprintf(os.Stdout, "Last viewed board id: %d\n", lastViewedBoardID)
+	}
 }
 
 func (a *App) Loading(flag bool) {

--- a/internal/app/colors.go
+++ b/internal/app/colors.go
@@ -2,21 +2,22 @@ package app
 
 import (
 	"fmt"
+	"os"
+	"sync"
+
 	"github.com/gdamore/tcell/v2"
 	os2 "github.com/mk-5/fjira/internal/os"
 	"gopkg.in/yaml.v3"
-	"os"
 )
 
 var (
-	schemeMap map[string]interface{}
-	colorsMap = map[string]tcell.Color{}
+	schemeMap    map[string]interface{}
+	colorsMap    = map[string]tcell.Color{}
+	colorsLoaded sync.Once
 )
 
 func Color(c string) tcell.Color {
-	if len(colorsMap) == 0 {
-		MustLoadColorScheme()
-	}
+	colorsLoaded.Do(func() { MustLoadColorScheme() })
 	if color, ok := colorsMap[c]; ok {
 		return color
 	}

--- a/internal/app/fuzzy_find.go
+++ b/internal/app/fuzzy_find.go
@@ -45,6 +45,10 @@ type FuzzyFindResult struct {
 	Match string
 }
 
+func (f *FuzzyFind) Destroy() {}
+
+func (f *FuzzyFind) Init() {}
+
 const (
 	ResultsMarginBottom     = 3
 	WriteIndicator          = "> "

--- a/internal/boards/board_view.go
+++ b/internal/boards/board_view.go
@@ -81,7 +81,7 @@ func NewBoardView(project *jira.Project, boardConfiguration *jira.BoardConfigura
 	}
 	bottomBar := ui.CreateBottomLeftBar()
 	bottomBar.AddItem(ui.CreateArrowsNavigateItem())
-	bottomBar.AddItem(ui.CreateSelectItem())
+	bottomBar.AddItem(ui.NewMoveIssueBarItem())
 	bottomBar.AddItem(ui.NewAssigneeFilterBarItem())
 	bottomBar.AddItem(ui.NewOpenBarItem())
 	bottomBar.AddItem(ui.NewCancelBarItem())
@@ -224,6 +224,10 @@ func (b *boardView) SetGoBackFn(f func()) {
 
 func (b *boardView) HandleKeyEvent(ev *tcell.EventKey) {
 	if app.GetApp().IsLoading() {
+		return
+	}
+	if ev.Key() == tcell.KeyEnter && !b.issueSelected && b.highlightedIssue != nil && b.highlightedIssue.Id != "" {
+		app.GoTo("issue", b.highlightedIssue.Id, b.reopen, b.api)
 		return
 	}
 	if !b.issueSelected {

--- a/internal/boards/board_view.go
+++ b/internal/boards/board_view.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mk-5/fjira/internal/app"
 	"github.com/mk-5/fjira/internal/jira"
 	"github.com/mk-5/fjira/internal/ui"
+	"github.com/mk-5/fjira/internal/users"
 )
 
 const (
@@ -32,6 +33,8 @@ type boardView struct {
 	activeSprint           *jira.SprintItem
 	project                *jira.Project
 	issues                 []jira.Issue
+	allIssues              []jira.Issue
+	assigneeFilter         *jira.User
 	statusesColumnsMap     map[string]int
 	columnStatusesMap      map[int][]string
 	columnsX               map[int]int
@@ -79,6 +82,7 @@ func NewBoardView(project *jira.Project, boardConfiguration *jira.BoardConfigura
 	bottomBar := ui.CreateBottomLeftBar()
 	bottomBar.AddItem(ui.CreateArrowsNavigateItem())
 	bottomBar.AddItem(ui.CreateSelectItem())
+	bottomBar.AddItem(ui.NewAssigneeFilterBarItem())
 	bottomBar.AddItem(ui.NewOpenBarItem())
 	bottomBar.AddItem(ui.NewCancelBarItem())
 	selectedIssueBottomBar := ui.CreateBottomLeftBar()
@@ -184,6 +188,11 @@ func (b *boardView) Resize(screenX, screenY int) {
 func (b *boardView) Init() {
 	app.GetApp().Loading(true)
 	b.issues, _ = b.fetchIssues()
+	b.allIssues = make([]jira.Issue, len(b.issues))
+	copy(b.allIssues, b.issues)
+	if b.assigneeFilter != nil {
+		b.applyAssigneeFilter(b.assigneeFilter)
+	}
 	b.refreshIssuesSummaries()
 	b.refreshIssuesRows()
 	b.setInitialCursorX()
@@ -342,6 +351,9 @@ func (b *boardView) handleActions() {
 			switch action {
 			case ui.ActionSelect:
 				b.issueSelected = true
+			case ui.ActionSearchByAssignee:
+				b.runSelectAssigneeFilter()
+				return
 			case ui.ActionCancel:
 				if b.goBackFn != nil {
 					b.goBackFn()
@@ -488,4 +500,96 @@ func centerString(str string, width int) string {
 	}
 	spaces := int(float64(width-len(str)) / 2)
 	return strings.Repeat(" ", spaces) + str + strings.Repeat(" ", width-(spaces+len(str)))
+}
+
+func (b *boardView) runSelectAssigneeFilter() {
+	app.GetApp().ClearNow()
+	app.GetApp().Loading(true)
+	assignees := b.getBoardAssignees()
+	assignees = append(assignees, jira.User{DisplayName: ui.MessageAll})
+	assigneeStrings := users.FormatJiraUsers(assignees)
+	fuzzyFind := app.NewFuzzyFind(ui.MessageSelectUser, assigneeStrings)
+	app.GetApp().SetView(fuzzyFind)
+	app.GetApp().Loading(false)
+	if user := <-fuzzyFind.Complete; true {
+		app.GetApp().ClearNow()
+		if user.Index >= 0 && len(assignees) > 0 {
+			selectedUser := &assignees[user.Index]
+			if selectedUser.DisplayName == ui.MessageAll {
+				b.clearAssigneeFilter()
+			} else {
+				b.applyAssigneeFilter(selectedUser)
+			}
+		}
+		b.reopen()
+		go b.handleActions()
+	}
+}
+
+func (b *boardView) getBoardAssignees() []jira.User {
+	assigneeNames := make(map[string]struct{})
+	hasUnassigned := false
+	for _, issue := range b.allIssues {
+		assignee := issue.Fields.Assignee
+		if assignee.DisplayName != "" {
+			assigneeNames[assignee.DisplayName] = struct{}{}
+		} else {
+			hasUnassigned = true
+		}
+	}
+	filtered := make([]jira.User, 0, len(assigneeNames)+1)
+	for name := range assigneeNames {
+		filtered = append(filtered, jira.User{
+			DisplayName: name,
+			Name:        name,
+			Key:         name,
+		})
+	}
+	if hasUnassigned {
+		filtered = append(filtered, jira.User{DisplayName: ui.MessageUnassigned})
+	}
+	return filtered
+}
+
+func (b *boardView) applyAssigneeFilter(user *jira.User) {
+	b.assigneeFilter = user
+	b.issues = make([]jira.Issue, 0)
+	for _, issue := range b.allIssues {
+		assignee := issue.Fields.Assignee
+		if user.DisplayName == ui.MessageUnassigned {
+			if assignee.DisplayName == "" {
+				b.issues = append(b.issues, issue)
+			}
+			continue
+		}
+		if user.AccountId != "" {
+			if assignee.AccountId == user.AccountId {
+				b.issues = append(b.issues, issue)
+			}
+		} else if assignee.DisplayName == user.DisplayName {
+			b.issues = append(b.issues, issue)
+		}
+	}
+	b.refreshIssuesSummaries()
+	b.refreshIssuesRows()
+	b.cursorX = 0
+	b.cursorY = 0
+	b.scrollX = 0
+	b.scrollY = 0
+	b.setInitialCursorX()
+	b.refreshHighlightedIssue()
+}
+
+func (b *boardView) clearAssigneeFilter() {
+	b.assigneeFilter = nil
+	b.issues = make([]jira.Issue, len(b.allIssues))
+	copy(b.issues, b.allIssues)
+	b.refreshIssuesSummaries()
+	b.refreshIssuesRows()
+	b.cursorX = 0
+	b.cursorY = 0
+	b.scrollX = 0
+	b.scrollY = 0
+	b.setInitialCursorX()
+	b.refreshHighlightedIssue()
 }

--- a/internal/boards/board_view.go
+++ b/internal/boards/board_view.go
@@ -87,6 +87,7 @@ func NewBoardView(project *jira.Project, boardConfiguration *jira.BoardConfigura
 	bottomBar.AddItem(ui.CreateArrowsNavigateItem())
 	bottomBar.AddItem(ui.NewMoveIssueBarItem())
 	bottomBar.AddItem(ui.NewAssigneeFilterBarItem())
+	bottomBar.AddItem(ui.NewCreateIssueBarItem())
 	bottomBar.AddItem(ui.NewOpenBarItem())
 	bottomBar.AddItem(ui.NewCancelBarItem())
 	selectedIssueBottomBar := ui.CreateBottomLeftBar()
@@ -434,6 +435,16 @@ func (b *boardView) handleActions() {
 			case ui.ActionSearchByAssignee:
 				b.runSelectAssigneeFilter()
 				return
+			case ui.ActionCreateIssue:
+				projectId := ""
+				if b.project != nil {
+					projectId = b.project.Id
+				}
+				boardId := 0
+				if b.boardConfiguration != nil {
+					boardId = b.boardConfiguration.Id
+				}
+				ui.OpenCreateIssueInBrowser(b.api, projectId, boardId)
 			case ui.ActionCancel:
 				if b.goBackFn != nil {
 					b.goBackFn()

--- a/internal/boards/board_view.go
+++ b/internal/boards/board_view.go
@@ -61,6 +61,9 @@ type boardView struct {
 }
 
 func NewBoardView(project *jira.Project, boardConfiguration *jira.BoardConfiguration, filterJQL string, api jira.Api) app.View {
+	if boardConfiguration != nil {
+		app.SetLastViewedBoardID(boardConfiguration.Id)
+	}
 	col := 0
 	statusesColumnsMap := map[string]int{}
 	columnStatusesMap := map[int][]string{}

--- a/internal/boards/board_view.go
+++ b/internal/boards/board_view.go
@@ -358,7 +358,6 @@ func (b *boardView) handleActions() {
 			case ui.ActionOpen:
 				app.GoTo("issue", b.highlightedIssue.Id, b.reopen, b.api)
 			}
-		default: //nolint
 		}
 	}
 }

--- a/internal/boards/board_view.go
+++ b/internal/boards/board_view.go
@@ -299,10 +299,10 @@ func (b *boardView) drawColumnsHeaders(screen tcell.Screen) {
 }
 
 func (b *boardView) moveCursorRight() {
-	if b.cursorX+1 >= len(b.statusesColumnsMap) {
+	if b.cursorX+1 >= len(b.columns) {
 		return
 	}
-	b.cursorX = app.MinInt(len(b.columns), b.cursorX+1)
+	b.cursorX = app.MinInt(len(b.columns)-1, b.cursorX+1)
 	b.cursorY = 0
 	if b.issueSelected {
 		b.moveIssue(b.highlightedIssue, 1)
@@ -472,7 +472,9 @@ func (b *boardView) ensureHighlightInViewport() {
 	if b.highlightedIssue == nil {
 		return
 	}
-	if b.scrollX+(b.cursorX*b.columnSize)+b.columnSize > b.screenX { // highlighted issue out of screen
+	if b.cursorX == 0 {
+		b.scrollX = 0
+	} else if b.scrollX+(b.cursorX*b.columnSize)+b.columnSize > b.screenX { // highlighted issue out of screen
 		b.scrollX = app.MaxInt(0, (b.cursorX-2)*b.columnSize)
 	}
 	if b.scrollY+b.cursorY > b.scrollY { // highlighted issue out of screen

--- a/internal/boards/board_view.go
+++ b/internal/boards/board_view.go
@@ -381,6 +381,18 @@ func (b *boardView) findNextValidColumn(startColumn, direction int) int {
 }
 
 func (b *boardView) moveCursorRight() {
+	// In move-issue mode, allow stepping into any adjacent column (including
+	// empty ones); skipping empties only makes sense for cursor navigation,
+	// not for the user explicitly moving an issue to a column they can see.
+	if b.issueSelected {
+		if b.cursorX+1 >= len(b.columns) {
+			return
+		}
+		b.cursorX = app.MinInt(len(b.columns)-1, b.cursorX+1)
+		b.cursorY = 0
+		b.moveIssue(b.highlightedIssue, 1)
+		return
+	}
 	nextColumn := b.findNextValidColumn(b.cursorX, 1)
 	if nextColumn == -1 {
 		return
@@ -392,10 +404,6 @@ func (b *boardView) moveCursorRight() {
 	} else {
 		b.cursorY = 0
 	}
-	if b.issueSelected {
-		b.moveIssue(b.highlightedIssue, 1)
-		return
-	}
 	if !b.refreshHighlightedIssue() {
 		return
 	}
@@ -403,6 +411,15 @@ func (b *boardView) moveCursorRight() {
 }
 
 func (b *boardView) moveCursorLeft() {
+	if b.issueSelected {
+		if b.cursorX-1 < 0 {
+			return
+		}
+		b.cursorX = app.MaxInt(0, b.cursorX-1)
+		b.cursorY = 0
+		b.moveIssue(b.highlightedIssue, -1)
+		return
+	}
 	nextColumn := b.findNextValidColumn(b.cursorX, -1)
 	if nextColumn == -1 {
 		return
@@ -413,10 +430,6 @@ func (b *boardView) moveCursorLeft() {
 		b.cursorY = positions[0]
 	} else {
 		b.cursorY = 0
-	}
-	if b.issueSelected {
-		b.moveIssue(b.highlightedIssue, -1)
-		return
 	}
 	if !b.refreshHighlightedIssue() {
 		return

--- a/internal/boards/board_view.go
+++ b/internal/boards/board_view.go
@@ -2,6 +2,7 @@ package boards
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/gdamore/tcell/v2"
@@ -245,13 +246,22 @@ func (b *boardView) HandleKeyEvent(ev *tcell.EventKey) {
 		b.moveCursorLeft()
 	}
 	if ev.Key() == tcell.KeyUp || ev.Rune() == vimUp {
-		b.cursorY = app.MaxInt(0, b.cursorY-1)
-		b.refreshHighlightedIssue()
+		if b.columnHasVisibleIssues(b.cursorX) {
+			newY := b.findNextIssuePosition(-1)
+			if newY != b.cursorY {
+				b.cursorY = newY
+				b.refreshHighlightedIssue()
+			}
+		}
 	}
 	if ev.Key() == tcell.KeyDown || ev.Rune() == vimDown {
-		// TODO - get number of issues in column
-		b.cursorY = app.MinInt(1000, b.cursorY+1)
-		b.refreshHighlightedIssue()
+		if b.columnHasVisibleIssues(b.cursorX) {
+			newY := b.findNextIssuePosition(1)
+			if newY != b.cursorY {
+				b.cursorY = newY
+				b.refreshHighlightedIssue()
+			}
+		}
 	}
 }
 
@@ -314,37 +324,100 @@ func (b *boardView) drawColumnsHeaders(screen tcell.Screen) {
 	}
 }
 
+func (b *boardView) columnHasVisibleIssues(column int) bool {
+	for _, issue := range b.issues {
+		if b.issuesColumn[issue.Id] == column {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *boardView) getIssuePositionsInColumn(column int) []int {
+	positions := make([]int, 0)
+	for _, issue := range b.issues {
+		if b.issuesColumn[issue.Id] == column {
+			positions = append(positions, b.issuesRow[issue.Id]-1)
+		}
+	}
+	sort.Ints(positions)
+	return positions
+}
+
+func (b *boardView) findNextIssuePosition(direction int) int {
+	positions := b.getIssuePositionsInColumn(b.cursorX)
+	if len(positions) == 0 {
+		return b.cursorY
+	}
+	if direction > 0 {
+		for _, pos := range positions {
+			if pos > b.cursorY {
+				return pos
+			}
+		}
+		return positions[len(positions)-1]
+	}
+	for i := len(positions) - 1; i >= 0; i-- {
+		if positions[i] < b.cursorY {
+			return positions[i]
+		}
+	}
+	return positions[0]
+}
+
+func (b *boardView) findNextValidColumn(startColumn, direction int) int {
+	currentColumn := startColumn
+	for i := 0; i < len(b.columns); i++ {
+		currentColumn += direction
+		if currentColumn < 0 || currentColumn >= len(b.columns) {
+			return -1
+		}
+		if b.columnHasVisibleIssues(currentColumn) {
+			return currentColumn
+		}
+	}
+	return -1
+}
+
 func (b *boardView) moveCursorRight() {
-	if b.cursorX+1 >= len(b.columns) {
+	nextColumn := b.findNextValidColumn(b.cursorX, 1)
+	if nextColumn == -1 {
 		return
 	}
-	b.cursorX = app.MinInt(len(b.columns)-1, b.cursorX+1)
-	b.cursorY = 0
+	b.cursorX = nextColumn
+	positions := b.getIssuePositionsInColumn(nextColumn)
+	if len(positions) > 0 {
+		b.cursorY = positions[0]
+	} else {
+		b.cursorY = 0
+	}
 	if b.issueSelected {
 		b.moveIssue(b.highlightedIssue, 1)
 		return
 	}
-	// no issues in a column
-	if f := b.refreshHighlightedIssue(); !f {
-		b.moveCursorRight()
+	if !b.refreshHighlightedIssue() {
 		return
 	}
 	b.scrollY = 0
 }
 
 func (b *boardView) moveCursorLeft() {
-	if b.cursorX-1 < 0 {
+	nextColumn := b.findNextValidColumn(b.cursorX, -1)
+	if nextColumn == -1 {
 		return
 	}
-	b.cursorX = app.MaxInt(0, b.cursorX-1)
-	b.cursorY = 0
+	b.cursorX = nextColumn
+	positions := b.getIssuePositionsInColumn(nextColumn)
+	if len(positions) > 0 {
+		b.cursorY = positions[0]
+	} else {
+		b.cursorY = 0
+	}
 	if b.issueSelected {
 		b.moveIssue(b.highlightedIssue, -1)
 		return
 	}
-	// no issues in a column
-	if f := b.refreshHighlightedIssue(); !f {
-		b.moveCursorLeft()
+	if !b.refreshHighlightedIssue() {
 		return
 	}
 	b.scrollY = 0
@@ -415,6 +488,9 @@ func (b *boardView) pointCursorTo(issueId string) {
 }
 
 func (b *boardView) refreshIssuesRows() {
+	// Reset so filtered-out issues don't linger from a prior pass.
+	b.issuesRow = map[string]int{}
+	b.issuesColumn = map[string]int{}
 	rows := map[int]int{}
 	for _, issue := range b.issues {
 		column := b.statusesColumnsMap[issue.Fields.Status.Id]
@@ -426,6 +502,8 @@ func (b *boardView) refreshIssuesRows() {
 }
 
 func (b *boardView) refreshIssuesSummaries() {
+	// Reset so filtered-out issues don't linger from a prior pass.
+	b.issuesSummaries = map[string]string{}
 	for _, issue := range b.issues {
 		b.issuesSummaries[issue.Id] = fmt.Sprintf("%s %s", issue.Key, issue.Fields.Summary)
 	}
@@ -435,11 +513,18 @@ func (b *boardView) setInitialCursorX() {
 	if len(b.issuesColumn) == 0 {
 		return
 	}
-	b.cursorX = len(b.columnsX)
+	leftmostColumn := len(b.columnsX)
 	for _, v := range b.issuesColumn {
-		if v < b.cursorX {
-			b.cursorX = v
+		if v < leftmostColumn {
+			leftmostColumn = v
 		}
+	}
+	b.cursorX = leftmostColumn
+	positions := b.getIssuePositionsInColumn(leftmostColumn)
+	if len(positions) > 0 {
+		b.cursorY = positions[0]
+	} else {
+		b.cursorY = 0
 	}
 }
 

--- a/internal/boards/board_view_test.go
+++ b/internal/boards/board_view_test.go
@@ -335,6 +335,102 @@ func Test_boardView_Init(t *testing.T) {
 	}
 }
 
+func Test_boardView_assigneeFiltering(t *testing.T) {
+	screen := tcell.NewSimulationScreen("utf-8")
+	_ = screen.Init() //nolint:errcheck
+	defer screen.Fini()
+
+	type args struct {
+		assigneeFilter string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		expectedIssues int
+	}{
+		{"should filter by specific assignee", args{assigneeFilter: "John Doe"}, 2},
+		{"should show all issues when 'All' is selected", args{assigneeFilter: "All"}, 4},
+		{"should show unassigned issues", args{assigneeFilter: "Unassigned"}, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app.InitTestApp(screen)
+			api := jira.NewJiraApiMock(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+				body := `{
+    "expand": "schema,names",
+    "startAt": 0,
+    "maxResults": 100,
+    "total": 4,
+    "issues": [
+        {"id": "1", "key": "TEST-1", "fields": {"summary": "First issue", "assignee": {"accountId": "john-doe", "displayName": "John Doe"}, "status": {"id": "10000"}}},
+        {"id": "2", "key": "TEST-2", "fields": {"summary": "Second issue", "assignee": {"accountId": "john-doe", "displayName": "John Doe"}, "status": {"id": "10001"}}},
+        {"id": "3", "key": "TEST-3", "fields": {"summary": "Third issue", "assignee": {"accountId": "jane-smith", "displayName": "Jane Smith"}, "status": {"id": "10002"}}},
+        {"id": "4", "key": "TEST-4", "fields": {"summary": "Fourth issue", "assignee": {"accountId": "", "displayName": ""}, "status": {"id": "10003"}}}
+    ]
+}`
+				_, _ = w.Write([]byte(body)) //nolint:errcheck
+			})
+			view := NewBoardView(&jira.Project{}, &jira.BoardConfiguration{}, "", api).(*boardView)
+			view.Init()
+
+			switch tt.args.assigneeFilter {
+			case "John Doe":
+				view.applyAssigneeFilter(&jira.User{AccountId: "john-doe", DisplayName: "John Doe"})
+			case "All":
+				view.clearAssigneeFilter()
+			case "Unassigned":
+				view.applyAssigneeFilter(&jira.User{DisplayName: "Unassigned"})
+			}
+
+			assert.Equal(t, tt.expectedIssues, len(view.issues))
+		})
+	}
+}
+
+func Test_boardView_getBoardAssignees(t *testing.T) {
+	view := &boardView{
+		allIssues: []jira.Issue{
+			{Fields: jira.IssueFields{Assignee: struct {
+				AccountId   string `json:"accountId"`
+				DisplayName string `json:"displayName"`
+			}{AccountId: "john-doe", DisplayName: "John Doe"}}},
+			{Fields: jira.IssueFields{Assignee: struct {
+				AccountId   string `json:"accountId"`
+				DisplayName string `json:"displayName"`
+			}{AccountId: "jane-smith", DisplayName: "Jane Smith"}}},
+			{Fields: jira.IssueFields{Assignee: struct {
+				AccountId   string `json:"accountId"`
+				DisplayName string `json:"displayName"`
+			}{AccountId: "", DisplayName: ""}}},
+		},
+	}
+
+	assignees := view.getBoardAssignees()
+	assert.Equal(t, 3, len(assignees)) // 2 named + 1 Unassigned
+
+	foundUnassigned := false
+	for _, a := range assignees {
+		if a.DisplayName == "Unassigned" {
+			foundUnassigned = true
+			break
+		}
+	}
+	assert.True(t, foundUnassigned)
+}
+
+func Test_boardView_assigneeFilterInitialState(t *testing.T) {
+	screen := tcell.NewSimulationScreen("utf-8")
+	_ = screen.Init() //nolint:errcheck
+	defer screen.Fini()
+	app.InitTestApp(screen)
+
+	view := NewBoardView(&jira.Project{}, &jira.BoardConfiguration{}, "", nil).(*boardView)
+	assert.NotNil(t, view)
+	assert.NotNil(t, view.bottomBar)
+	assert.Nil(t, view.assigneeFilter)
+}
+
 func Test_boardView_SetSprints_SelectsActiveSprint(t *testing.T) {
 	// given
 	view := NewBoardView(&jira.Project{}, &jira.BoardConfiguration{}, "", nil).(*boardView)

--- a/internal/boards/board_view_test.go
+++ b/internal/boards/board_view_test.go
@@ -192,7 +192,7 @@ func Test_boardView_HandleKeyEvent(t *testing.T) {
 			tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone),
 			tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone),
 			tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone),
-		}}, 1, 1},
+		}}, 1, 0},
 		{"should handle key events and move cursor, and move issue using VIM keys", args{ev: []*tcell.EventKey{
 			tcell.NewEventKey(0, 'l', tcell.ModNone),
 			tcell.NewEventKey(0, 'l', tcell.ModNone),
@@ -201,7 +201,7 @@ func Test_boardView_HandleKeyEvent(t *testing.T) {
 			tcell.NewEventKey(0, 'j', tcell.ModNone),
 			tcell.NewEventKey(0, 'j', tcell.ModNone),
 			tcell.NewEventKey(0, 'k', tcell.ModNone),
-		}}, 1, 1},
+		}}, 1, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/fjira/fjira.go
+++ b/internal/fjira/fjira.go
@@ -2,6 +2,7 @@ package fjira
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -43,6 +44,7 @@ type Fjira struct {
 // CliArgs TODO - drop it, and use cobra directly
 type CliArgs struct {
 	ProjectId       string
+	BoardId         int
 	IssueKey        string
 	Workspace       string
 	WorkspaceSwitch bool
@@ -107,6 +109,10 @@ func (f *Fjira) registerGoTos() {
 
 func (f *Fjira) bootstrap(args *CliArgs) {
 	defer f.app.PanicRecover()
+	if args.BoardId != 0 {
+		f.openBoardDirect(args.BoardId, args.ProjectId)
+		return
+	}
 	if args.WorkspaceSwitch {
 		app.GoTo("workspaces-switch")
 		return
@@ -132,5 +138,57 @@ func (f *Fjira) bootstrap(args *CliArgs) {
 	time.Sleep(350 * time.Millisecond)
 	f.app.RunOnAppRoutine(func() {
 		app.GoTo("projects", f.api)
+	})
+}
+
+// openBoardDirect opens a board view directly from CLI by board ID, resolving
+// its associated project automatically when not supplied. Every failure path
+// surfaces a flash error so the user isn't left staring at an empty screen.
+func (f *Fjira) openBoardDirect(boardId int, projectKey string) {
+	boardConfig, err := f.api.GetBoardConfiguration(boardId)
+	if err != nil {
+		app.Error(fmt.Sprintf("Cannot load board %d: %s", boardId, err.Error()))
+		return
+	}
+	if boardConfig == nil {
+		app.Error(fmt.Sprintf("Board %d not found", boardId))
+		return
+	}
+	if projectKey == "" {
+		projectKey = boardConfig.Location.Key
+	}
+	boardItem := &jira.BoardItem{
+		Id:   boardConfig.Id,
+		Self: boardConfig.Self,
+		Name: boardConfig.Name,
+		Type: boardConfig.Type,
+	}
+	if projectKey != "" {
+		project, err := f.api.FindProject(projectKey)
+		if err != nil {
+			app.Error(fmt.Sprintf("Cannot load project %s: %s", projectKey, err.Error()))
+			return
+		}
+		if project == nil {
+			app.Error(fmt.Sprintf("Project %s not found", projectKey))
+			return
+		}
+		f.app.RunOnAppRoutine(func() {
+			app.GoTo("boards", project, boardItem, nil, f.api)
+		})
+		return
+	}
+	projects, err := f.api.GetBoardProjects(boardId)
+	if err != nil {
+		app.Error(fmt.Sprintf("Cannot load projects for board %d: %s", boardId, err.Error()))
+		return
+	}
+	if len(projects) == 0 {
+		app.Error(fmt.Sprintf("Board %d has no associated projects", boardId))
+		return
+	}
+	project := &projects[0]
+	f.app.RunOnAppRoutine(func() {
+		app.GoTo("boards", project, boardItem, nil, f.api)
 	})
 }

--- a/internal/issues/issue.go
+++ b/internal/issues/issue.go
@@ -41,6 +41,7 @@ var (
 		ui.NavItemConfig{Action: ui.ActionAssigneeChange, Text1: ui.MessageAssignUser, Text2: "[a]", Rune: 'a'},
 		ui.NavItemConfig{Action: ui.ActionComment, Text1: ui.MessageComment, Text2: "[c]", Rune: 'c'},
 		ui.NavItemConfig{Action: ui.ActionAddLabel, Text1: ui.MessageLabel, Text2: "[l]", Rune: 'l'},
+		ui.NavItemConfig{Action: ui.ActionCreateIssue, Text1: ui.MessageCreateIssue, Text2: "[F6]", Key: tcell.KeyF6},
 		ui.NavItemConfig{Action: ui.ActionOpen, Text1: ui.MessageOpen, Text2: "[o]", Rune: 'o'},
 	}
 )
@@ -192,6 +193,14 @@ func (view *issueView) handleIssueAction() {
 			return
 		case ui.ActionAddLabel:
 			app.GoTo("labels-add", view.issue, view.reopen, view.api)
+			return
+		case ui.ActionCreateIssue:
+			projectId := ""
+			if view.issue != nil {
+				projectId = view.issue.Fields.Project.Id
+			}
+			ui.OpenCreateIssueInBrowser(view.api, projectId, 0)
+			go view.handleIssueAction()
 			return
 		case ui.ActionOpen:
 			OpenIssueInBrowser(view.issue, view.api)

--- a/internal/issues/jql_builder.go
+++ b/internal/issues/jql_builder.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 )
 
+// DefaultBoundedJql is used when no other restriction would be present in the
+// generated query. Atlassian Cloud's /rest/api/3/search/jql endpoint rejects
+// unbounded queries with HTTP 400 ("Unbounded JQL queries are not allowed here").
+const DefaultBoundedJql = "created >= -30d"
+
 func BuildSearchIssuesJql(project *jira.Project, query string, status *jira.IssueStatus, user *jira.User, label string) string {
 	jql := ""
 	if project != nil && project.Id != ui.MessageAll {
@@ -34,5 +39,9 @@ func BuildSearchIssuesJql(project *jira.Project, query string, status *jira.Issu
 	if query != "" && issueRegExp.MatchString(query) {
 		jql = jql + fmt.Sprintf(" OR issuekey=\"%s\"", query)
 	}
-	return fmt.Sprintf("%s %s", strings.TrimLeft(jql, " AND"), orderBy)
+	jql = strings.TrimLeft(jql, " AND")
+	if jql == "" {
+		jql = DefaultBoundedJql
+	}
+	return fmt.Sprintf("%s %s", jql, orderBy)
 }

--- a/internal/issues/jql_builder_test.go
+++ b/internal/issues/jql_builder_test.go
@@ -23,6 +23,8 @@ func Test_buildSearchIssuesJql(t *testing.T) {
 		{"should create valid jql", args{project: &jira.Project{Id: "123"}}, "project=123 ORDER BY status"},
 		{"should create valid jql", args{project: &jira.Project{Id: "123"}, query: "abc"}, "project=123 AND summary~\"abc*\" ORDER BY status"},
 		{"should create valid jql", args{project: &jira.Project{Id: ui.MessageAll, Key: ui.MessageAll}, query: "abc"}, "summary~\"abc*\" ORDER BY status"},
+		{"should fall back to bounded predicate when no restrictions", args{project: &jira.Project{Id: ui.MessageAll, Key: ui.MessageAll}}, "created >= -30d ORDER BY status"},
+		{"should fall back to bounded predicate when project is nil", args{}, "created >= -30d ORDER BY status"},
 		{"should create valid jql", args{
 			project: &jira.Project{Id: "123"}, query: "abc", status: &jira.IssueStatus{Id: "st1"}},
 			"project=123 AND summary~\"abc*\" AND status=st1 ORDER BY status",

--- a/internal/issues/open.go
+++ b/internal/issues/open.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"fmt"
+
 	"github.com/mk-5/fjira/internal/app"
 	"github.com/mk-5/fjira/internal/jira"
 )

--- a/internal/issues/search_issues.go
+++ b/internal/issues/search_issues.go
@@ -46,6 +46,7 @@ var (
 		ui.NavItemConfig{Action: ui.ActionSearchByAssignee, Text1: ui.MessageByAssignee, Text2: "[F2]", Key: tcell.KeyF2},
 		ui.NavItemConfig{Action: ui.ActionSearchByLabel, Text1: ui.MessageByLabel, Text2: "[F3]", Key: tcell.KeyF3},
 		ui.NavItemConfig{Action: ui.ActionBoards, Text1: ui.MessageBoards, Text2: "[F4]", Key: tcell.KeyF4},
+		ui.NavItemConfig{Action: ui.ActionCreateIssue, Text1: ui.MessageCreateIssue, Text2: "[F6]", Key: tcell.KeyF6},
 	}
 )
 
@@ -203,6 +204,14 @@ func (view *searchIssuesView) handleSearchActions() {
 			view.runSelectLabel()
 		case ui.ActionBoards:
 			view.runSelectBoard()
+		case ui.ActionCreateIssue:
+			projectId := ""
+			if view.project != nil {
+				projectId = view.project.Id
+			}
+			ui.OpenCreateIssueInBrowser(view.api, projectId, 0)
+			go view.runIssuesFuzzyFind()
+			go view.handleSearchActions()
 		}
 	}
 }

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -27,6 +27,7 @@ type Api interface {
 	GetBoardConfiguration(boardId int) (*BoardConfiguration, error)
 	GetBoardSprints(boardId int) ([]SprintItem, error)
 	GetBoardSprintIssues(boardId int, sprintId int, page int32, pageSize int32) ([]Issue, int32, int32, error)
+	GetBoardProjects(boardId int) ([]Project, error)
 	GetFilter(filterId string) (*Filter, error)
 	GetMyFilters() ([]Filter, error)
 	Close()

--- a/internal/jira/jira_boards.go
+++ b/internal/jira/jira_boards.go
@@ -145,6 +145,24 @@ func (api *httpApi) GetBoardConfiguration(boardId int) (*BoardConfiguration, err
 	return &result, nil
 }
 
+// GetBoardProjects fetches the projects associated with a board.
+// Used when --board=<id> is supplied without --project=<key> to resolve
+// the project context for the board view.
+func (api *httpApi) GetBoardProjects(boardId int) ([]Project, error) {
+	url := fmt.Sprintf("/rest/agile/1.0/board/%d/project", boardId)
+	resultBytes, err := api.jiraRequest("GET", url, &nilParams{}, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Values []Project `json:"values"`
+	}
+	if err := json.Unmarshal(resultBytes, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Values, nil
+}
+
 func (api *httpApi) GetBoardSprints(boardId int) ([]SprintItem, error) {
 	params := &GetAllSprintsQueryParams{State: "active,future"}
 	resultBytes, err := api.jiraRequest("GET", fmt.Sprintf(FindBoardSprintsUrl, boardId), params, nil)

--- a/internal/projects/search_projects.go
+++ b/internal/projects/search_projects.go
@@ -1,6 +1,8 @@
 package projects
 
 import (
+	"strings"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/mk-5/fjira/internal/app"
 	"github.com/mk-5/fjira/internal/jira"
@@ -61,7 +63,19 @@ func (view *searchProjectsView) findProjects() []jira.Project {
 	if err != nil {
 		app.Error(err.Error())
 	}
+	if err == nil && len(projects) == 0 && isAtlassianCloud(view.api.GetApiUrl()) {
+		app.Error(ui.MessageNoProjectsTokenHint)
+	}
 	return projects
+}
+
+// isAtlassianCloud reports whether the Jira REST URL points at an Atlassian
+// Cloud site. On Cloud, an expired/wrong-scope API token returns 200 with an
+// empty project list instead of 401 — so an empty result is the strongest
+// available signal of an auth problem there. The token-management URL in the
+// hint is Cloud-specific, so we only show it for Cloud workspaces.
+func isAtlassianCloud(apiUrl string) bool {
+	return strings.Contains(apiUrl, ".atlassian.net")
 }
 
 func (view *searchProjectsView) reopen() {

--- a/internal/ui/create_issue.go
+++ b/internal/ui/create_issue.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/mk-5/fjira/internal/app"
+	"github.com/mk-5/fjira/internal/jira"
+)
+
+// OpenCreateIssueInBrowser opens the Jira create-issue modal in the user's
+// browser, pre-populating project and board context where available.
+// Uses the legacy CreateIssue!default.jspa endpoint which Atlassian Cloud
+// redirects to the modern UI; on-prem Jira Server keeps the legacy form.
+// Pass empty projectId / zero boardId to omit those query params.
+func OpenCreateIssueInBrowser(api jira.Api, projectId string, boardId int) {
+	jiraUrl := api.GetApiUrl()
+	createUrl := fmt.Sprintf("%s/secure/CreateIssue!default.jspa", jiraUrl)
+	params := url.Values{}
+	if projectId != "" && projectId != MessageAll {
+		params.Add("pid", projectId)
+	}
+	if boardId > 0 {
+		params.Add("boardId", fmt.Sprintf("%d", boardId))
+	}
+	if len(params) > 0 {
+		createUrl += "?" + params.Encode()
+	}
+	app.OpenLink(createUrl)
+}

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -74,6 +74,7 @@ const (
 	MessageNavigate                  = "Navigate "
 	MessageMoveIssue                 = "Move issue "
 	MessageSelect                    = "Select "
+	MessageMove                      = "Move "
 	MessageUnselect                  = "Unselect "
 	MessageNew                       = "New "
 	MessageDelete                    = "Delete "

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -66,6 +66,7 @@ const (
 	MessageBoards                    = "boards"
 	MessageAssignUser                = "Assign user "
 	MessageComment                   = "Comment "
+	MessageCreateIssue               = "Create issue "
 	MessageLabel                     = "Label "
 	MessageYes                       = "Yes "
 	MessageOpen                      = "Open "

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -34,6 +34,7 @@ const (
 	MessageSelectFilter              = "Select filter or ESC to cancel"
 	MessageSearchProjectsLoading     = "Fetching projects"
 	MessageSelectProject             = "Select project or ESC to exit"
+	MessageNoProjectsTokenHint       = "No projects visible. If you expected projects, your API token may be expired. Manage tokens: https://id.atlassian.com/manage-profile/security/api-tokens"
 	MessageChangingAssigneeTo        = "Are you sure about changing %s assignee to [%s]?"
 	MessageCannotAssignUser          = "Cannot assign user %s to ticket %s. Reason: %s AccountId: %s"
 	MessageCannotAddLabel            = "Cannot add label %s to ticket %s. Reason: %s"

--- a/internal/ui/navigation.go
+++ b/internal/ui/navigation.go
@@ -221,6 +221,18 @@ func NewAssigneeFilterBarItem() *app.ActionBarItem {
 	}
 }
 
+func NewMoveIssueBarItem() *app.ActionBarItem {
+	return &app.ActionBarItem{
+		Id:          int(ActionSelect),
+		Text1:       MessageMove,
+		Text2:       "[m]",
+		Text1Style:  bottomBarItemDefaultStyle(),
+		Text2Style:  bottomBarActionBarKeyBold(),
+		TriggerKey:  -1,
+		TriggerRune: 'm',
+	}
+}
+
 func bottomBarItemDefaultStyle() tcell.Style {
 	return app.DefaultStyle().Background(app.Color("navigation.bottom.background")).Foreground(app.Color("navigation.bottom.foreground1"))
 }

--- a/internal/ui/navigation.go
+++ b/internal/ui/navigation.go
@@ -210,6 +210,17 @@ func NewSaveBarItem() *app.ActionBarItem {
 	}
 }
 
+func NewAssigneeFilterBarItem() *app.ActionBarItem {
+	return &app.ActionBarItem{
+		Id:         int(ActionSearchByAssignee),
+		Text1:      MessageByAssignee,
+		Text2:      "[F2]",
+		Text1Style: bottomBarItemDefaultStyle(),
+		Text2Style: bottomBarActionBarKeyBold(),
+		TriggerKey: tcell.KeyF2,
+	}
+}
+
 func bottomBarItemDefaultStyle() tcell.Style {
 	return app.DefaultStyle().Background(app.Color("navigation.bottom.background")).Foreground(app.Color("navigation.bottom.foreground1"))
 }

--- a/internal/ui/navigation.go
+++ b/internal/ui/navigation.go
@@ -23,6 +23,7 @@ const (
 	ActionAddLabel
 	ActionSelect
 	ActionUnselect
+	ActionCreateIssue
 )
 
 type NavItemConfig struct {
@@ -218,6 +219,17 @@ func NewAssigneeFilterBarItem() *app.ActionBarItem {
 		Text1Style: bottomBarItemDefaultStyle(),
 		Text2Style: bottomBarActionBarKeyBold(),
 		TriggerKey: tcell.KeyF2,
+	}
+}
+
+func NewCreateIssueBarItem() *app.ActionBarItem {
+	return &app.ActionBarItem{
+		Id:         int(ActionCreateIssue),
+		Text1:      MessageCreateIssue,
+		Text2:      "[F6]",
+		Text1Style: bottomBarItemDefaultStyle(),
+		Text2Style: bottomBarActionBarKeyBold(),
+		TriggerKey: tcell.KeyF6,
 	}
 }
 


### PR DESCRIPTION
## Summary

Board view overhaul: 11 commits bundled because they all touch
`internal/boards/board_view.go` and splitting would mean repeated
rebases against shared code paths. Today's two `master`-level fixes
(JQL bounded predicate on `/rest/api/3/search/jql` + token-expiry hint
for empty Atlassian Cloud project lists) ride along since the branch
builds on master.

## What's in

**Fixes:**
- `perf: drop busy-waiting default case in board handleActions` — CPU spin on idle (10% on one core)
- `fix: concurrent map access in app.Color()` — replaced lazy-init with `sync.Once`
- `fix: board view scrolling crash + first-column off-screen` — bounds check used wrong collection
- `fix: bounded predicate default for /rest/api/3/search/jql` — Atlassian Cloud rejects unbounded queries
- `fix: move-issue mode allows stepping into empty columns` — restores arrow-key behavior in move mode

**Features:**
- `feat: F2 assignee filter on board view` — pulls unique assignees from loaded issues
- `feat: Enter opens issue detail from board; m enters move-across-columns mode` — Enter is the universal "drill in"; move-mode now under `m`
- `feat: --board=<id> CLI arg to open a board directly` — resolves project context automatically, surfaces every error via `app.Error`
- `feat: issue-aware board navigation` — arrow keys skip empty columns, vertical movement snaps to issue rows
- `feat: Create Issue (F6) on board, issues list, issue detail views` — shared helper in `internal/ui/create_issue.go`
- `feat: hint about expired API token when projects list is empty on Atlassian Cloud` — surfaces the token-management URL

**Enabler:**
- `chore: no-op Destroy/Init on FuzzyFind to satisfy View interface` — required for F2 fuzzy-find swap

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` passes (the pre-existing `/dev/tty` failure in `cmd/fjira-cli/commands` is unchanged — present on master before this PR)
- [x] Binary `--help` shows `--board` flag
- [ ] Interactive: open board via `fjira --board=<id>`
- [ ] Interactive: F2 opens assignee fuzzy-find on board view
- [ ] Interactive: `m` then arrows moves issue across columns (including into empty columns)
- [ ] Interactive: Enter on board issue opens detail view
- [ ] Interactive: F6 opens browser to CreateIssue URL with project (+ board) context
- [ ] Interactive: navigating empty column with arrow keys skips it
- [ ] Interactive: scroll to last column then back, first column visible
- [ ] Interactive: on Atlassian Cloud, expired token shows the new "manage tokens" hint

## Follow-ups (not in this PR)
- Race in `app.Color()` still has a tiny unclosed window: the eager call at `app.go:97` doesn't go through `sync.Once`, so a goroutine calling `Color()` before `initAppWithScreen` returns can race. Routing through `sync.Once` is one line but breaks `colors_test.go`'s reset-and-reload pattern; needs a test-only escape hatch first.
- A handful of pre-existing lint hints (`interface{}` → `any`, `slicescontains`, `simplifycompositelit`) are unchanged here.

## Files of note
- New: `internal/ui/create_issue.go` (shared CreateIssue URL helper)
- New: `internal/ui/messages.go` adds `MessageMove`, `MessageCreateIssue`, `MessageNoProjectsTokenHint`
- New: `internal/ui/navigation.go` adds `NewAssigneeFilterBarItem`, `NewMoveIssueBarItem`, `NewCreateIssueBarItem`, action enum `ActionCreateIssue`
- Changed: `internal/jira/jira.go` + `jira_boards.go` add `GetBoardProjects(boardId)`
- Changed: `internal/app/app.go` adds `SetLastViewedBoardID` + shutdown print
- Changed: `internal/app/colors.go` uses `sync.Once`
